### PR TITLE
Promote GRB 2.0 from 2.0.0-rc.0 to 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,15 @@
 # Changelog
 
-## 2.0.0-rc.0 — 2026-04-22
+## 2.0.0 — 2026-04-24
 
-First GRB 2.0 release candidate. Version surfaces across `mcp/package.json`,
+First GRB 2.0 release. Version surfaces across `mcp/package.json`,
 `mcp/package-lock.json`, `addons/godot-runtime-bridge/plugin.cfg`,
 `addons/godot-runtime-bridge/runtime_bridge/EditorDock.gd`, and the MCP server
-name/startup banner in `mcp/index.js` now agree on `2.0.0-rc.0`. Prior RC
-iterations are expected before a final `2.0.0` tag.
+name/startup banner in `mcp/index.js` now agree on `2.0.0`. The previously
+staged `2.0.0-rc.0` identity was not published; this entry replaces it and
+covers the same repaired surfaces verified by the final release-gate smoke.
 
-This RC covers the full-repo GRB 2.0 proof workflow. Addon/archive/export
+This release covers the full-repo GRB 2.0 proof workflow. Addon/archive/export
 packaging remains addon-oriented; the GRB 2.0 CLI, templates, proving ground,
 and product-shape verification still require a full repo clone.
 
@@ -55,8 +56,9 @@ and product-shape verification still require a full repo clone.
   and product-shape tooling. The README channel section and
   `docs/grb2-release-candidate-readiness.md` were updated to match.
 - **Release identity** — All authoritative GRB version surfaces bumped from
-  `1.0.6` to `2.0.0-rc.0`. The product-shape check's startup-banner regex in
-  `mcp/check_versions.mjs` now accepts pre-release suffixes.
+  `1.0.6` to `2.0.0`. The product-shape check's startup-banner regex in
+  `mcp/check_versions.mjs` now accepts pre-release suffixes as well as the
+  final release identity.
 - **`verify:release` aggregate** — The `mcp/` npm script now runs
   `verify:grb2:shape` in addition to the existing versions+live-smoke chain.
   The legacy versions+live-smoke-only behavior is preserved under a new

--- a/addons/godot-runtime-bridge/plugin.cfg
+++ b/addons/godot-runtime-bridge/plugin.cfg
@@ -3,5 +3,5 @@
 name="Godot Runtime Bridge"
 description="TCP debug server + MCP bridge for AI-driven testing and runtime automation. Zero overhead in production."
 author="Matt Munroe"
-version="2.0.0-rc.0"
+version="2.0.0"
 script="runtime_bridge_plugin.gd"

--- a/addons/godot-runtime-bridge/runtime_bridge/EditorDock.gd
+++ b/addons/godot-runtime-bridge/runtime_bridge/EditorDock.gd
@@ -3,7 +3,7 @@ extends VBoxContainer
 
 const _Commands := preload("res://addons/godot-runtime-bridge/runtime_bridge/Commands.gd")
 
-const VERSION := "2.0.0-rc.0"
+const VERSION := "2.0.0"
 const SCREENSHOTS_DIR := "res://debug/screenshots"
 const GRB_COMMANDS_AUTOLOAD_PATH := "res://addons/godot-runtime-bridge/runtime_bridge/GRBCommands.gd"
 

--- a/docs/grb2-release-candidate-readiness.md
+++ b/docs/grb2-release-candidate-readiness.md
@@ -115,9 +115,11 @@ Do not treat addon-only or AssetLib delivery as equivalent to the full-repo GRB 
 Sprint 13 Slice 1 has now delivered:
 
 - **version/tag decision** — all GRB version surfaces now report
-  `2.0.0-rc.0`; `verify:versions` enforces this parity
+  `2.0.0`; `verify:versions` enforces this parity. The previously staged
+  `2.0.0-rc.0` identity was not published; the repo promoted directly to
+  `2.0.0` after the final release-gate smoke
 - **release changelog section** — `CHANGELOG.md` now has a real
-  `2.0.0-rc.0 — 2026-04-22` section in place of the open-ended `Unreleased`
+  `2.0.0 — 2026-04-24` section in place of the open-ended `Unreleased`
   bucket
 - **release verification naming** — `verify:release` is now the honest
   aggregate (shape + versions + live smoke); `verify:release:live` preserves

--- a/mcp/index.js
+++ b/mcp/index.js
@@ -1124,7 +1124,7 @@ function errResult(r) {
 // ── MCP server setup ──
 
 const mcpServer = new Server(
-  { name: "godot-runtime-bridge", version: "2.0.0-rc.0" },
+  { name: "godot-runtime-bridge", version: "2.0.0" },
   { capabilities: { tools: {} } }
 );
 
@@ -1150,7 +1150,7 @@ await mcpServer.connect(transport);
 // Startup notice — visible in Cursor's MCP output panel (Settings → Tools & MCP → godot-runtime-bridge → Logs)
 // If GRB tools are not appearing in Cursor, the most common cause is the server not being enabled.
 process.stderr.write(
-  "[GRB] MCP server started (godot-runtime-bridge v2.0.0-rc.0)\n" +
+  "[GRB] MCP server started (godot-runtime-bridge v2.0.0)\n" +
   "[GRB] If tools are not appearing in Cursor:\n" +
   "[GRB]   1. Open Cursor → Settings → Tools & MCP\n" +
   "[GRB]   2. Find 'godot-runtime-bridge' under Installed MCP Servers\n" +

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "godot-runtime-bridge-mcp",
-  "version": "2.0.0-rc.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "godot-runtime-bridge-mcp",
-      "version": "2.0.0-rc.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1"

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "godot-runtime-bridge-mcp",
-  "version": "2.0.0-rc.0",
+  "version": "2.0.0",
   "description": "MCP server for Godot Runtime Bridge — AI-driven game testing and automation",
   "type": "module",
   "main": "index.js",

--- a/tools/verify_grb2_product_shape.mjs
+++ b/tools/verify_grb2_product_shape.mjs
@@ -438,7 +438,7 @@ function checkChannelAndDocTruth() {
   assertIncludes(readinessDoc, "experiential quality or E-tier proof", "release-candidate readiness doc");
   assertIncludes(readinessDoc, "addon/archive/export packaging is addon-oriented", "release-candidate readiness doc");
   assertIncludes(readinessDoc, "the GRB 2.0 proof workflow requires a full repo clone", "release-candidate readiness doc");
-  assertIncludes(readinessDoc, "2.0.0-rc.0", "release-candidate readiness doc");
+  assertIncludes(readinessDoc, "2.0.0", "release-candidate readiness doc");
   assertIncludes(readinessDoc, "verify:release:live", "release-candidate readiness doc");
   assertIncludes(readinessDoc, "final release smoke on the intended release target", "release-candidate readiness doc");
 


### PR DESCRIPTION
## Summary

Final release identity promotion. The `2.0.0-rc.0` RC was not published; this PR replaces the staged RC identity with the final `2.0.0` release across all six version surfaces, and updates release-facing truth (changelog top section, readiness doc, product-shape verifier assertion) to match.

## Files changed (8)

- `mcp/package.json` — `version` 2.0.0-rc.0 to 2.0.0
- `mcp/package-lock.json` — root + `packages[""]` `version` 2.0.0-rc.0 to 2.0.0
- `addons/godot-runtime-bridge/plugin.cfg` — `version` 2.0.0-rc.0 to 2.0.0
- `addons/godot-runtime-bridge/runtime_bridge/EditorDock.gd` — `VERSION` 2.0.0-rc.0 to 2.0.0
- `mcp/index.js` — server version + startup banner 2.0.0-rc.0 to 2.0.0
- `CHANGELOG.md` — top heading rewritten to `## 2.0.0 — 2026-04-24`; opening paragraph rewritten to honestly describe this as the first GRB 2.0 release (RC was never published); release-identity bullet text updated
- `docs/grb2-release-candidate-readiness.md` — version/tag and changelog bullets updated to reflect the direct-to-2.0.0 promotion
- `tools/verify_grb2_product_shape.mjs` — readiness-doc assertion updated from `"2.0.0-rc.0"` to `"2.0.0"`

Both surviving `2.0.0-rc.0` mentions in the repo are intentional historical references in CHANGELOG and the readiness doc, each phrased "was not published" so release truth stays honest.

## Local validation

- `npm run verify:versions` — all 6 surfaces aligned at `2.0.0`
- `npm run verify:grb2:shape` — 11/11 product-shape checks pass
- `npm run verify:release -- --godot-exe "C:\Godot Runtime Bridge\Godot_v4.6-stable_win64_console.exe" --project "examples/grb2-proving-ground"` — `ok=true`, 24 capabilities, 0 errors, 0 warnings, screenshot captured

## Test plan

- [ ] CI `GRB Release Smoke` passes on this branch
- [ ] Diff is exactly 8 files / +21 / -17
- [ ] After merge, tag `v2.0.0` on the resulting `main` HEAD and publish release notes from the `2.0.0` block of CHANGELOG.md

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a repo-wide version/label promotion and doc/verifier string updates, with no behavioral changes to runtime logic.
> 
> **Overview**
> Promotes the staged GRB 2.0 release identity from `2.0.0-rc.0` to the final `2.0.0` across all authoritative version surfaces (addon `plugin.cfg`, editor dock `VERSION`, MCP server metadata/banner, and `mcp` package manifests).
> 
> Updates release-facing truth to match: the top `CHANGELOG.md` entry is rewritten as the `2.0.0 — 2026-04-24` release (noting the RC was never published), the readiness doc reflects the direct-to-`2.0.0` promotion, and `tools/verify_grb2_product_shape.mjs` now asserts `2.0.0` in that doc.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40a90209997e7178f33586ad32f983af362c5b4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->