### PR TITLE
Make README release checklist final-release-neutral

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,13 +525,13 @@ CLI/template/tooling surfaces do not drift silently.
 
 `verify:grb` performs a release-grade smoke run: launch, `ping`, `auth_info`, `capabilities`, `runtime_info`, `get_errors`, `screenshot`, and clean `quit`. Artifacts are written to `mcp/reports/release-smoke/`.
 
-#### Release Candidate Checklist
+#### Release Verification Checklist
 
 See [`docs/grb2-release-candidate-readiness.md`](docs/grb2-release-candidate-readiness.md)
-for the compact GRB 2.0 release-candidate readiness surface and Sprint 13
-handoff truth.
+for the compact GRB 2.0 release-readiness surface and Sprint 13/14 handoff
+truth.
 
-Before tagging a release candidate, run:
+Before tagging a release, run:
 
 - `npm run verify:versions`
   - does **not** launch Godot


### PR DESCRIPTION
## Summary

Tiny pre-tag README hygiene pass. Makes the release checklist subsection honest for a direct `2.0.0` release rather than an RC.

## Changes

- `README.md` only:
  - Subsection heading: `Release Candidate Checklist` → `Release Verification Checklist`
  - Intro line: `Before tagging a release candidate, run:` → `Before tagging a release, run:`
  - Linked-doc description softened from `release-candidate readiness surface and Sprint 13 handoff truth` to `release-readiness surface and Sprint 13/14 handoff truth` to match the renamed heading and actual sprint history. The linked file `docs/grb2-release-candidate-readiness.md` is intentionally not renamed.
- No checklist content was added, removed, or reordered.

The previously-mentioned stale top-level `godot-runtime-bridge-v0.1.5.zip` artifact was already removed in Sprint 13 (verified: no `*.zip` files in the working tree, none tracked). No additional cleanup was performed in this PR.

## Validation

- `npm run verify:grb2:shape` — 11/11 product-shape checks pass after the README edit.

## Test plan

- [ ] CI `GRB Release Smoke` passes on this branch
- [ ] Diff is exactly `README.md | 8 ++++----` (1 file, +4/-4)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that renames the release checklist wording; no code or runtime behavior is affected.
> 
> **Overview**
> Updates `README.md` release section wording to be final-release neutral: renames **Release Candidate Checklist** to **Release Verification Checklist**, changes the intro to “Before tagging a release…”, and adjusts the linked-doc description to “release-readiness” with updated sprint handoff wording. No checklist steps or commands are added, removed, or reordered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f46152e17932c6d4d0e83d36f83c58bf368fef6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->