### PR TITLE
Tighten readiness-doc version assertion against substring drift

### DIFF
--- a/tools/verify_grb2_product_shape.mjs
+++ b/tools/verify_grb2_product_shape.mjs
@@ -438,7 +438,10 @@ function checkChannelAndDocTruth() {
   assertIncludes(readinessDoc, "experiential quality or E-tier proof", "release-candidate readiness doc");
   assertIncludes(readinessDoc, "addon/archive/export packaging is addon-oriented", "release-candidate readiness doc");
   assertIncludes(readinessDoc, "the GRB 2.0 proof workflow requires a full repo clone", "release-candidate readiness doc");
-  assertIncludes(readinessDoc, "2.0.0", "release-candidate readiness doc");
+  // Use the dated release heading as the needle so this check fails if the
+  // doc ever drifts back to RC-only mentions. Plain "2.0.0" would be a
+  // substring of "2.0.0-rc.0" and silently pass.
+  assertIncludes(readinessDoc, "2.0.0 — 2026-04-24", "release-candidate readiness doc");
   assertIncludes(readinessDoc, "verify:release:live", "release-candidate readiness doc");
   assertIncludes(readinessDoc, "final release smoke on the intended release target", "release-candidate readiness doc");
 


### PR DESCRIPTION
## Summary

Closes the substring-drift footgun in the readiness-doc version assertion that Bugbot flagged on the previous promotion PR.

## Problem

In `tools/verify_grb2_product_shape.mjs`, the readiness-doc check is:

```js
assertIncludes(readinessDoc, "2.0.0", "release-candidate readiness doc");
```

`assertIncludes` is a `String.includes()` substring check, and `"2.0.0-rc.0".includes("2.0.0") === true`. So this assertion would silently pass even if the readiness doc had never been promoted off the RC string. The check is vacuous after the rc.0 to 2.0.0 promotion.

## Fix

Tighten the needle to the dated release heading that is already present in the readiness doc:

```js
assertIncludes(readinessDoc, "2.0.0 — 2026-04-24", "release-candidate readiness doc");
```

This needle is unique to the final 2.0.0 release identity, so the assertion fails immediately if the doc ever drifts back to RC-only wording.

A short comment was added above the line explaining why a more specific needle is required.

## Validation

- `npm run verify:grb2:shape` against current `main` plus this fix: **11/11 ok, exit 0**.
- Negative test: temporarily regressed the readiness doc's `2.0.0 — 2026-04-24` back to `2.0.0-rc.0 — 2026-04-22`; verifier **failed** with `missing expected text: 2.0.0 — 2026-04-24` (exit 1). Doc restored; verifier passes again.

## Diff

`tools/verify_grb2_product_shape.mjs` only — `+4 / -1`. No other files touched.

## Test plan

- [ ] CI `GRB Release Smoke` passes on this branch
- [ ] Diff is exactly 1 file / +4 / -1
