### PR TITLE
GRB 2.0.2: add proof discipline tooling and templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 2.0.2 — 2026-05-06
+
+### Added
+
+- Added a lightweight informational worktree preflight helper for agentic GRB
+  work.
+- Added project-template guidance for proof harnesses with deterministic probes,
+  JSON debug snapshots, and markdown proof reports.
+- Added a canonical proof report template with before/after worktree state,
+  W/R/E evidence, not-claimed limits, and next-slice guidance.
+
+### Changed
+
+- Tightened agent-facing guidance around preserving existing dirty worktree
+  changes and proving work honestly rather than merely compiling it.
+
+### Notes
+
+- No runtime protocol, bridge behavior, compare logic, security architecture, or
+  packaging behavior changed in this patch.
+
 ## 2.0.1 — 2026-04-24
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -200,6 +200,11 @@ This is a **full-repo workflow**, not an addon-only workflow. It depends on the
 repo-root GRB launcher (`grb.cmd` on Windows, `./grb` on POSIX), plus
 `templates/grb2/`, `examples/grb2-proving-ground/`, and repo-side docs/tools.
 
+GRB proof work is meant to help agents prove changes honestly, not merely
+compile code or blur unrelated edits into the same story. For project slices,
+capture dirty worktree state before and after the change, keep proof surfaces
+small, and say what automation did **not** prove.
+
 A few plain-English terms first:
 
 - **Mission** — a short predefined script GRB runs against your game. For example, `smoke_boot` launches the game, waits, takes screenshots, and checks for errors. Missions don't require changes to your game code.
@@ -363,6 +368,11 @@ Use `grb/mission_authoring.md` in your project for short examples of panel toggl
 
 If the mission needs a stable runtime value, use `grb/runtime_proof_hooks.md` for guidance on adding small, safe project helper methods for `call_method` or choosing a clear `get_property` read.
 
+If the mission needs deterministic setup, timestamp/state seeking, JSON debug
+snapshots, or a slice closeout report, use the generated
+`grb/proof_harness_template.md` and `grb/proof_report_template.md` as
+authoring guides.
+
 Then run it:
 
 ```bash
@@ -523,6 +533,17 @@ node tools/verify_grb2_product_shape.mjs
 ```
 
 It does not launch Godot. It checks small deterministic product-layer truths such as readable baseline rejection reasons, blocked comparison summaries, proof-bundle review handoff, and generated/proving-ground contract shape.
+
+For agentic project work, use the informational preflight helper before editing
+or writing a proof closeout:
+
+```bash
+node tools/grb_worktree_preflight.mjs
+```
+
+It classifies dirty files as likely source, docs, generated artifacts, proof
+reports, or suspicious/out-of-scope so prior/user work is visible before the
+slice begins.
 
 ### Release Verification
 

--- a/addons/godot-runtime-bridge/plugin.cfg
+++ b/addons/godot-runtime-bridge/plugin.cfg
@@ -3,5 +3,5 @@
 name="Godot Runtime Bridge"
 description="TCP debug server + MCP bridge for AI-driven testing and runtime automation. Zero overhead in production."
 author="Matt Munroe"
-version="2.0.1"
+version="2.0.2"
 script="runtime_bridge_plugin.gd"

--- a/addons/godot-runtime-bridge/runtime_bridge/EditorDock.gd
+++ b/addons/godot-runtime-bridge/runtime_bridge/EditorDock.gd
@@ -3,7 +3,7 @@ extends VBoxContainer
 
 const _Commands := preload("res://addons/godot-runtime-bridge/runtime_bridge/Commands.gd")
 
-const VERSION := "2.0.1"
+const VERSION := "2.0.2"
 const SCREENSHOTS_DIR := "res://debug/screenshots"
 const GRB_COMMANDS_AUTOLOAD_PATH := "res://addons/godot-runtime-bridge/runtime_bridge/GRBCommands.gd"
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -45,7 +45,9 @@ correctness, UX quality, or E-tier experience.
 ## Linux CI and xvfb
 
 Godot still needs a display server for rendered screenshot flows on headless
-Linux runners. Use `xvfb-run` when you need live rendering.
+Linux runners. That is **not** the same thing as launching Godot with
+`--headless`. Use `xvfb-run` when you need live rendering so GRB still gets a
+real render context for screenshots.
 
 Minimal shape:
 

--- a/docs/grb2-release-candidate-readiness.md
+++ b/docs/grb2-release-candidate-readiness.md
@@ -114,13 +114,14 @@ Do not treat addon-only or AssetLib delivery as equivalent to the full-repo GRB 
 
 Sprint 13 Slice 1 has now delivered:
 
-- **version/tag decision** — all GRB version surfaces now report
-  `2.0.0`; `verify:versions` enforces this parity. The previously staged
-  `2.0.0-rc.0` identity was not published; the repo promoted directly to
-  `2.0.0` after the final release-gate smoke
+- **version/tag decision** — all authoritative GRB version surfaces now
+  report `2.0.2`; `verify:versions` enforces this parity. `2.0.0` was the
+  initial GRB 2.0 launch, `2.0.1` clarified the security posture, and `2.0.2`
+  is the current patch release for agentic proof discipline documentation and
+  tooling only
 - **release changelog section** — `CHANGELOG.md` now has a real
-  `2.0.0 — 2026-04-24` section in place of the open-ended `Unreleased`
-  bucket
+  `2.0.2 — 2026-05-06` patch section above the prior `2.0.1` patch and the original
+  `2.0.0 — 2026-04-24` launch section
 - **release verification naming** — `verify:release` is now the honest
   aggregate (shape + versions + live smoke); `verify:release:live` preserves
   the prior versions+live-smoke-only behavior

--- a/examples/grb2-proving-ground/README.md
+++ b/examples/grb2-proving-ground/README.md
@@ -26,11 +26,17 @@ From the GRB repo root, sync the addon into this project:
 node examples/grb2-proving-ground/tools/sync_grb_addon.mjs
 ```
 
-Then open the project once in Godot so `.godot/` metadata is created:
+Then open the project once in Godot so `.godot/` metadata is created. If you
+only need a nonvisual editor/import metadata pass, a command like this can
+work:
 
 ```bash
 Godot_v4.6-stable_win64_console.exe --headless --editor --quit --path examples/grb2-proving-ground
 ```
+
+That command is for metadata/import prep only. Do **not** use Godot
+`--headless` for the proof mission commands below. GRB screenshot/runtime proof
+should use the normal or console Godot executable with a real render context.
 
 The synced `addons/`, `.godot/`, and `grb_reports/` folders are local validation artifacts and are ignored by git.
 

--- a/mcp/index.js
+++ b/mcp/index.js
@@ -1124,7 +1124,7 @@ function errResult(r) {
 // ── MCP server setup ──
 
 const mcpServer = new Server(
-  { name: "godot-runtime-bridge", version: "2.0.1" },
+  { name: "godot-runtime-bridge", version: "2.0.2" },
   { capabilities: { tools: {} } }
 );
 
@@ -1150,7 +1150,7 @@ await mcpServer.connect(transport);
 // Startup notice — visible in Cursor's MCP output panel (Settings → Tools & MCP → godot-runtime-bridge → Logs)
 // If GRB tools are not appearing in Cursor, the most common cause is the server not being enabled.
 process.stderr.write(
-  "[GRB] MCP server started (godot-runtime-bridge v2.0.1)\n" +
+  "[GRB] MCP server started (godot-runtime-bridge v2.0.2)\n" +
   "[GRB] If tools are not appearing in Cursor:\n" +
   "[GRB]   1. Open Cursor → Settings → Tools & MCP\n" +
   "[GRB]   2. Find 'godot-runtime-bridge' under Installed MCP Servers\n" +

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "godot-runtime-bridge-mcp",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "godot-runtime-bridge-mcp",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1"

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "godot-runtime-bridge-mcp",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "MCP server for Godot Runtime Bridge — AI-driven game testing and automation",
   "type": "module",
   "main": "index.js",

--- a/templates/grb2/AGENTS.md
+++ b/templates/grb2/AGENTS.md
@@ -20,15 +20,24 @@ Use later, only when the stage calls for it:
 - `grb/mission_authoring.md` after `smoke_boot` passes and you are creating the next small mission.
 - `grb/runtime_proof_hooks.md` only when a `state_check` or runtime-readable proof needs a stable project state read.
 - `grb/regression_workflow.md` only after a small mission passes and you are deciding whether the run is a baseline candidate.
+- `grb/proof_harness_template.md` when a project-specific proof probe needs deterministic setup, JSON debug snapshots, or a small runtime state helper.
+- `grb/proof_report_template.md` when writing a slice closeout that needs before/after worktree state, W/R/E evidence, and explicit not-claimed limits.
 
 ## Working Rules
 
 - Keep implementation slices small enough to prove with one mission when possible.
+- Before editing, inspect dirty state with `git status --short` or the GRB
+  preflight helper. State what was already dirty and which paths you intend to
+  touch.
+- Preserve prior/user work in dirty files. If your slice must overlap an
+  existing dirty file, say so in the handoff.
 - Before claiming a change works, say which proof tier was reached and link the proof bundle.
 - Say what was not proven and what still needs human review.
 - Do not claim experiential proof unless a human has reviewed or played the slice.
 - Put proof bundles under `grb_reports/`.
 - Record recurring project-specific traps in `grb/gotchas.md`.
+- When handing off a slice, include before/after worktree state so unrelated
+  local changes do not get mistaken for proof of your work.
 
 ## Customize First
 
@@ -41,6 +50,12 @@ Use later, only when the stage calls for it:
 
 Run `grb/missions/smoke_boot.yaml` before making larger changes. A passing smoke boot targets W-tier wiring proof. It can provide R-tier screenshot evidence, but it does not prove visual correctness by itself. E-tier still needs human review.
 
+Do not treat automated proof as Godot `--headless`. For screenshot-capable GRB
+runtime proof, launch the normal or console Godot executable with a real render
+context, even when the run is unattended. Reserve `--headless` for
+project-specific nonvisual editor, import, or precompile tasks that do not need
+meaningful viewport screenshots.
+
 Prefer the project-local truth in `grb.project.yaml` over reconstructing GRB
 paths from memory. `grb init` records the expected full-repo launcher linkage
 there for this specific project.
@@ -48,6 +63,11 @@ there for this specific project.
 Before `smoke_boot`, run the repo-root `doctor` command if readiness is
 uncertain. It checks the local project contract, addon, metadata, mission file,
 and Godot executable path without launching Godot.
+
+Do not minimize the proof window when you need reliable runtime evidence.
+Godot throttles hard when minimized. Leave a real window/render context
+available, or rely on the launcher's window sizing and `GDRB_FORCE_WINDOWED`
+behavior instead of forcing `--headless`.
 
 After the run, inspect:
 
@@ -81,6 +101,10 @@ Customize the goal, one interaction step, and human handoff before claiming proo
 When replacing scaffold TODOs, use `grb/mission_authoring.md` as the local cookbook. It owns second-mission authoring guidance.
 
 When a `state_check` mission needs project-specific runtime state, use `grb/runtime_proof_hooks.md` before adding helper methods. Skip it for missions that only need screenshots or simple interaction.
+
+When a mission needs deterministic setup or a JSON-friendly debug snapshot,
+use `grb/proof_harness_template.md` as an authoring guide. It is a
+project-specific proof template, not a new automatic runner.
 
 ## Regression Stage
 

--- a/templates/grb2/grb/mission_authoring.md
+++ b/templates/grb2/grb/mission_authoring.md
@@ -10,6 +10,10 @@ If a mission may later become a regression surface, author it with stable
 evidence in mind from the start. Compare is only as trustworthy as the mission's
 capture discipline.
 
+If the mission needs deterministic setup, a JSON-friendly debug snapshot, or a
+small project-specific proof probe, use `grb/proof_harness_template.md`. It is
+an authoring template for your project, not a new automatic proof runner.
+
 ## Pick a Pattern
 
 - `default`: use when the mission does not fit a named pattern yet.

--- a/templates/grb2/grb/proof_harness_template.md
+++ b/templates/grb2/grb/proof_harness_template.md
@@ -1,0 +1,138 @@
+# Project Proof Harness Template
+
+Use this when a project-specific feature needs a small deterministic proof probe
+that goes beyond a generic mission scaffold.
+
+This is an authoring template, not a new automatic proof runner and not a
+guarantee of correctness. It helps you expose and capture evidence that a human
+or coding agent can review honestly with W/R/E proof language.
+
+## What This Is For
+
+Use a proof harness when a mission needs one stable project-specific setup or
+state read, such as:
+
+- seek to a timestamp, checkpoint, room, or UI state
+- return a small JSON-friendly debug snapshot
+- capture before/after runtime state alongside screenshots
+- write a short markdown report that explains what was and was not shown
+
+Keep the harness narrow: one proof surface, one setup path, one set of evidence.
+
+## Recommended Shape
+
+1. Start from a small GRB mission, usually `transition`, `toggle`, or
+   `state_check`.
+2. Add a project helper method only when the mission needs stable project truth.
+3. Make the helper deterministic: no timestamps, frame counters, random seeds,
+   or broad engine dumps unless they are the proof target.
+4. Return a small JSON-friendly object with explicit keys.
+5. Capture a screenshot before and after the interaction.
+6. Capture runtime-readable state before and after the interaction.
+7. Write a markdown proof report using `grb/proof_report_template.md`.
+
+## Example Project Helpers
+
+These examples show the intended shape only. Rename nodes, methods, and fields
+for your project.
+
+```gdscript
+func grb_seek_proof_state(state_id: String) -> Dictionary:
+    match state_id:
+        "title":
+            show_title_screen()
+        "paused":
+            open_pause_menu()
+        "hud_mode_b":
+            set_debug_mode("mode_b")
+        _:
+            return {
+                "ok": false,
+                "state_id": state_id,
+                "error": "unknown proof state"
+            }
+
+    return grb_debug_snapshot()
+
+
+func grb_debug_snapshot() -> Dictionary:
+    return {
+        "ok": true,
+        "screen": current_screen_name,
+        "mode": current_mode,
+        "counter": score_counter,
+        "pause_panel_visible": pause_panel.visible
+    }
+```
+
+Good snapshot fields describe product truth. Avoid returning full scene trees,
+node internals, secrets, absolute machine paths, noisy frame/time values, or
+large object dumps.
+
+## Mission Step Shape
+
+Use existing mission-runner primitives. Do not invent a new action type for the
+harness.
+
+```yaml
+steps:
+  - action: runtime_info
+
+  - action: call_method
+    node: Main
+    method: grb_seek_proof_state
+    args: ["title"]
+    label: setup_snapshot
+
+  - action: screenshot
+    label: before_surface
+
+  - action: call_method
+    node: Main
+    method: grb_debug_snapshot
+    label: before_snapshot
+
+  - action: press_button
+    name: StartButton
+
+  - action: wait
+    ms: 300
+
+  - action: call_method
+    node: Main
+    method: grb_debug_snapshot
+    label: after_snapshot
+
+  - action: screenshot
+    label: after_surface
+
+  - action: screenshot_diff
+    a: before_surface
+    b: after_surface
+    issue_title: Expected the proof surface to change
+
+  - action: check_errors
+    label: proof_errors
+```
+
+The runtime values are captured into GRB run artifacts. If your project also
+writes a JSON debug snapshot file, keep it small and reference it from the
+proof report.
+
+## Markdown Proof Report
+
+Use `grb/proof_report_template.md` for the human-facing closeout. Include:
+
+- the exact proof commands
+- the before/after worktree state
+- the JSON snapshot fields reviewed
+- the screenshots reviewed
+- W-tier and R-tier evidence
+- E-tier evidence only when a human actually reviewed it
+- known issues and explicit "not claimed" limits
+
+## What This Does Not Prove
+
+The harness can make proof work more deterministic and reviewable. It still does
+not prove product correctness, design intent, accessibility, game feel, balance,
+or E-tier experience by itself.

--- a/templates/grb2/grb/proof_report_template.md
+++ b/templates/grb2/grb/proof_report_template.md
@@ -1,0 +1,73 @@
+# Proof Report Template
+
+Use this for project-specific slice closeouts when a coding agent changed files
+and collected GRB evidence. Keep it short, factual, and honest.
+
+## Worktree Preflight Before
+
+- Command: `git status --short` or `node <grb-repo>/tools/grb_worktree_preflight.mjs <project>`
+- Dirty state found before editing:
+  - TODO: list likely source edits, docs, generated artifacts, proof reports, or suspicious files
+- Prior/user work preserved:
+  - TODO: list any dirty files that existed before this slice and were not yours
+- Intended touch paths:
+  - TODO: list files/folders the slice was expected to edit
+
+## Files Changed
+
+- TODO: file path — short reason
+
+## What Changed
+
+Briefly explain the product/code/doc change in plain language.
+
+## Proof Commands
+
+```bash
+TODO: exact command run
+```
+
+Include failed or blocked commands too when they explain the proof boundary.
+
+## W-Tier Evidence
+
+W-tier answers: did the project launch/connect/run the intended automation path?
+
+- TODO: command output, proof bundle path, doctor result, or launch/connect evidence
+
+## R-Tier Evidence
+
+R-tier answers: what runtime artifacts were captured for review?
+
+- TODO: screenshots, runtime state, JSON debug snapshots, logs, comparison report, or `run.json`
+- Primary artifact to inspect:
+  - TODO: path
+
+## E-Tier Evidence
+
+E-tier requires human judgment. Do not claim it unless a human actually reviewed
+or played the slice.
+
+- Claimed: TODO yes/no
+- Human reviewer / review note: TODO
+
+## Known Issues / Not Claimed
+
+- TODO: what automation did not prove
+- TODO: unresolved visual/design/feel/product questions
+- TODO: flaky, noisy, or unstable evidence surfaces
+
+## Worktree Preflight After
+
+- Command: `git status --short` or `node <grb-repo>/tools/grb_worktree_preflight.mjs <project>`
+- Dirty state after the slice:
+  - TODO: list remaining changed files by likely category
+- New files/edits from this slice:
+  - TODO: list what you intentionally changed
+- Prior/user work still preserved:
+  - TODO: confirm unchanged prior dirty files, or explain any intentional overlap
+
+## Next Recommended Slice
+
+State the smallest useful next step. Do not hide broad follow-up work inside a
+single vague recommendation.

--- a/tools/grb_worktree_preflight.mjs
+++ b/tools/grb_worktree_preflight.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "child_process";
+import path from "path";
+
+const targetDir = path.resolve(process.argv[2] || process.cwd());
+
+function normalizePath(input) {
+  return input.replace(/\\/g, "/");
+}
+
+function parseStatusLine(line) {
+  const status = line.slice(0, 2);
+  const rawPath = line.slice(3).trim();
+  const displayPath = rawPath.includes(" -> ") ? rawPath.split(" -> ").pop() : rawPath;
+  return { status, path: displayPath };
+}
+
+function classify(filePath) {
+  const normalized = normalizePath(filePath);
+  const lower = normalized.toLowerCase();
+  const ext = path.extname(lower);
+
+  if (
+    lower.includes("/grb_reports/") ||
+    lower.startsWith("grb_reports/") ||
+    lower.includes("/reports/") ||
+    lower.includes("/mission_runner/") ||
+    lower.includes("/debug/screenshots/")
+  ) {
+    return "proof reports / validation artifacts";
+  }
+
+  if (
+    lower.startsWith(".godot/") ||
+    lower.includes("/.godot/") ||
+    lower.startsWith("node_modules/") ||
+    lower.includes("/node_modules/") ||
+    lower.startsWith(".cache/") ||
+    lower.includes("/.cache/") ||
+    lower.startsWith("coverage/") ||
+    lower.includes("/coverage/")
+  ) {
+    return "generated artifacts / local caches";
+  }
+
+  if (
+    ext === ".md" ||
+    lower === "readme.md" ||
+    lower === "changelog.md" ||
+    lower === "security.md" ||
+    lower === "protocol.md" ||
+    lower.startsWith("docs/") ||
+    lower.includes("/readme.md") ||
+    lower.startsWith("templates/") ||
+    lower.endsWith(".yaml") ||
+    lower.endsWith(".yml")
+  ) {
+    return "docs / project contract";
+  }
+
+  if (
+    [".gd", ".mjs", ".js", ".ts", ".json", ".cmd", ""].includes(ext) &&
+    (
+      lower.startsWith("addons/") ||
+      lower.startsWith("cli/") ||
+      lower.startsWith("mcp/") ||
+      lower.startsWith("missions/") ||
+      lower.startsWith("tools/") ||
+      lower === "grb" ||
+      lower === "grb.cmd"
+    )
+  ) {
+    return "source / tooling";
+  }
+
+  return "suspicious or out-of-scope until reviewed";
+}
+
+function runGitStatus(cwd) {
+  return spawnSync("git", ["status", "--short", "--untracked-files=all"], {
+    cwd,
+    encoding: "utf8",
+    windowsHide: true,
+  });
+}
+
+function printHeader() {
+  console.log("GRB worktree preflight");
+  console.log(`Path: ${targetDir}`);
+  console.log("");
+  console.log("This helper is informational. Categories are likely review hints, not definitive truth.");
+  console.log("Do not revert or overwrite dirty work unless the user explicitly asks.");
+  console.log("");
+}
+
+function printGuidance() {
+  console.log("");
+  console.log("Suggested agent preflight statement:");
+  console.log("- Current dirty state: summarize the categories above.");
+  console.log("- Intended touch paths: list the files/folders this slice will edit.");
+  console.log("- Preservation note: say which existing dirty files are prior/user work to preserve.");
+}
+
+printHeader();
+
+const result = runGitStatus(targetDir);
+
+if (result.error) {
+  const message = result.error.code === "ENOENT"
+    ? "git was not found on PATH, so dirty-state inspection could not run."
+    : `git status could not run: ${result.error.message}`;
+  console.log(`Status: unavailable - ${message}`);
+  printGuidance();
+  process.exit(0);
+}
+
+if (result.status !== 0) {
+  const stderr = (result.stderr || "").trim();
+  const stdout = (result.stdout || "").trim();
+  const details = stderr || stdout || `git exited with code ${result.status}`;
+  console.log(`Status: unavailable - ${details}`);
+  console.log("This may mean the path is not inside a git worktree.");
+  printGuidance();
+  process.exit(0);
+}
+
+const lines = (result.stdout || "").split(/\r?\n/).filter(Boolean);
+
+if (lines.length === 0) {
+  console.log("Status: clean");
+  printGuidance();
+  process.exit(0);
+}
+
+const grouped = new Map();
+
+for (const line of lines) {
+  const entry = parseStatusLine(line);
+  const category = classify(entry.path);
+  if (!grouped.has(category)) grouped.set(category, []);
+  grouped.get(category).push(entry);
+}
+
+console.log("Status: dirty");
+for (const [category, entries] of grouped.entries()) {
+  console.log(`\n${category}:`);
+  for (const entry of entries) {
+    console.log(`- ${entry.status.trim() || "modified"} ${entry.path}`);
+  }
+}
+
+printGuidance();

--- a/tools/verify_grb2_product_shape.mjs
+++ b/tools/verify_grb2_product_shape.mjs
@@ -24,6 +24,18 @@ function assertIncludes(text, needle, label) {
   assert(String(text).includes(needle), `${label} missing expected text: ${needle}`);
 }
 
+function assertConcept(text, label, concepts) {
+  const lowerText = String(text).toLowerCase().replace(/\s+/g, " ");
+  for (const concept of concepts) {
+    const alternatives = Array.isArray(concept) ? concept : [concept];
+    const matched = alternatives.some((needle) => lowerText.includes(String(needle).toLowerCase().replace(/\s+/g, " ")));
+    assert(
+      matched,
+      `${label} missing expected concept: ${alternatives.join(" OR ")}`
+    );
+  }
+}
+
 function assertReadableReason(raw, expected, forbidden = raw) {
   const rendered = baselineReasonText(raw);
   assertIncludes(rendered, expected, `reason ${raw}`);
@@ -397,17 +409,22 @@ function checkDoctorReadiness() {
 
 function checkChannelAndDocTruth() {
   const readme = fs.readFileSync(path.join(repoRoot, "README.md"), "utf-8");
+  const mcpReadme = fs.readFileSync(path.join(repoRoot, "mcp", "README.md"), "utf-8");
   const readinessDoc = fs.readFileSync(path.join(repoRoot, "docs", "grb2-release-candidate-readiness.md"), "utf-8");
   const legacyMissions = fs.readFileSync(path.join(repoRoot, "missions", "README.md"), "utf-8");
   const ciDoc = fs.readFileSync(path.join(repoRoot, "docs", "ci.md"), "utf-8");
   const authoring = fs.readFileSync(path.join(repoRoot, "templates", "grb2", "grb", "mission_authoring.md"), "utf-8");
+  const proofHarness = fs.readFileSync(path.join(repoRoot, "templates", "grb2", "grb", "proof_harness_template.md"), "utf-8");
+  const proofReport = fs.readFileSync(path.join(repoRoot, "templates", "grb2", "grb", "proof_report_template.md"), "utf-8");
   const regression = fs.readFileSync(path.join(repoRoot, "templates", "grb2", "grb", "regression_workflow.md"), "utf-8");
   const agents = fs.readFileSync(path.join(repoRoot, "templates", "grb2", "AGENTS.md"), "utf-8");
   const projectYaml = fs.readFileSync(path.join(repoRoot, "templates", "grb2", "grb.project.yaml"), "utf-8");
   const provingGround = fs.readFileSync(path.join(repoRoot, "examples", "grb2-proving-ground", "README.md"), "utf-8");
   const cliHelp = fs.readFileSync(path.join(repoRoot, "cli", "grb.mjs"), "utf-8");
+  const preflightHelper = fs.readFileSync(path.join(repoRoot, "tools", "grb_worktree_preflight.mjs"), "utf-8");
   const wrapperCmd = fs.readFileSync(path.join(repoRoot, "grb.cmd"), "utf-8");
   const wrapperPosix = fs.readFileSync(path.join(repoRoot, "grb"), "utf-8");
+  const mcpIndex = fs.readFileSync(path.join(repoRoot, "mcp", "index.js"), "utf-8");
 
   assert(fs.existsSync(path.join(repoRoot, "grb.cmd")), "repo-root grb.cmd launcher missing");
   assert(fs.existsSync(path.join(repoRoot, "grb")), "repo-root grb launcher missing");
@@ -426,6 +443,18 @@ function checkChannelAndDocTruth() {
   assertIncludes(readme, "`./grb ...` on POSIX", "README launcher truth");
   assertIncludes(readme, "Run `grb doctor`", "README doctor truth");
   assertIncludes(readme, "doctor` is a no-launch preflight check", "README doctor truth");
+  assertConcept(readme, "README headless doctrine", [
+    "headless",
+    ["windowed runtime", "real render context"],
+    "Reserve `--headless`",
+  ]);
+  assertConcept(readme, "README proof-discipline truth", [
+    "prove changes honestly",
+    "dirty worktree state before and after",
+    "what automation did **not** prove",
+    "proof_harness_template.md",
+    "proof_report_template.md",
+  ]);
   assertIncludes(readme, "docs/grb2-release-candidate-readiness.md", "README readiness-doc truth");
   assert(!readme.includes("node C:\\path\\to\\grb-main\\cli\\grb.mjs"), "README should not primarily teach raw cli/grb.mjs path");
 
@@ -438,10 +467,12 @@ function checkChannelAndDocTruth() {
   assertIncludes(readinessDoc, "experiential quality or E-tier proof", "release-candidate readiness doc");
   assertIncludes(readinessDoc, "addon/archive/export packaging is addon-oriented", "release-candidate readiness doc");
   assertIncludes(readinessDoc, "the GRB 2.0 proof workflow requires a full repo clone", "release-candidate readiness doc");
-  // Use the dated release heading as the needle so this check fails if the
-  // doc ever drifts back to RC-only mentions. Plain "2.0.0" would be a
-  // substring of "2.0.0-rc.0" and silently pass.
-  assertIncludes(readinessDoc, "2.0.0 — 2026-04-24", "release-candidate readiness doc");
+  assertConcept(readinessDoc, "release-candidate readiness doc", [
+    "2.0.2",
+    "2.0.1",
+    "2.0.0",
+    "verify:versions",
+  ]);
   assertIncludes(readinessDoc, "verify:release:live", "release-candidate readiness doc");
   assertIncludes(readinessDoc, "final release smoke on the intended release target", "release-candidate readiness doc");
 
@@ -452,10 +483,48 @@ function checkChannelAndDocTruth() {
   assertIncludes(ciDoc, "Repo-Level Release Smoke", "CI doc truth");
   assertIncludes(ciDoc, "Project-Level GRB 2.0 Proof Workflows", "CI doc truth");
   assertIncludes(ciDoc, "legacy mission runner", "CI doc truth");
+  assertConcept(ciDoc, "CI headless doctrine", [
+    "headless",
+    "real render context",
+    "xvfb-run",
+  ]);
 
   assertIncludes(authoring, "## Stable Capture Slots", "mission authoring contract");
   assertIncludes(authoring, "treat screenshot labels as", "mission authoring contract");
   assertIncludes(authoring, "stable surface rather than deep semantic understanding", "mission authoring contract");
+  assertConcept(authoring, "mission authoring proof-harness routing", [
+    "proof_harness_template.md",
+    "json-friendly debug snapshot",
+    "not a new automatic proof runner",
+  ]);
+  assertConcept(proofHarness, "proof harness template", [
+    "project-specific",
+    "not a new automatic proof runner",
+    "guarantee of correctness",
+    "json",
+    "markdown",
+    "w/r/e",
+    "not prove product correctness",
+  ]);
+  assertConcept(proofReport, "proof report template", [
+    "Worktree Preflight Before",
+    "Files Changed",
+    "What Changed",
+    "Proof Commands",
+    "W-Tier Evidence",
+    "R-Tier Evidence",
+    "E-Tier Evidence",
+    "Known Issues / Not Claimed",
+    "Worktree Preflight After",
+    "Next Recommended Slice",
+  ]);
+  assertConcept(preflightHelper, "worktree preflight helper", [
+    "git status",
+    "likely review hints",
+    "not definitive truth",
+    "Do not revert",
+    "untracked-files=all",
+  ]);
   assertIncludes(regression, "## Stable Evidence Surfaces", "regression workflow contract");
   assertIncludes(regression, "not a strong regression surface yet", "regression workflow contract");
   assertIncludes(agents, "Treat screenshot labels as capture slots", "agent contract");
@@ -463,17 +532,44 @@ function checkChannelAndDocTruth() {
   assertIncludes(agents, "grb_repo_root", "agent launcher contract");
   assertIncludes(agents, "local GRB repo linkage", "agent launcher contract");
   assertIncludes(agents, "repo-root `doctor` command", "agent doctor contract");
+  assertConcept(agents, "agent preflight/proof template contract", [
+    "git status --short",
+    "preserve prior/user work",
+    "proof_harness_template.md",
+    "proof_report_template.md",
+    "before/after worktree state",
+  ]);
+  assertConcept(agents, "agent headless doctrine", [
+    "headless",
+    "real render context",
+    "Do not minimize",
+  ]);
   assert(!agents.includes("node <path-to-grb-main>/cli/grb.mjs"), "AGENTS should not primarily teach raw cli/grb.mjs path");
   assertIncludes(projectYaml, "grb_repo_root", "project yaml launcher contract");
   assertIncludes(projectYaml, "<set-by-grb-init>", "project yaml launcher contract");
   assert(!projectYaml.includes("node <path-to-grb-main>/cli/grb.mjs"), "grb.project.yaml should not primarily teach raw cli/grb.mjs path");
   assertIncludes(provingGround, "grb.cmd mission run smoke_boot", "proving ground launcher truth");
   assertIncludes(provingGround, "..\\..\\grb.cmd mission run smoke_boot", "proving ground launcher truth");
+  assertConcept(provingGround, "proving ground headless doctrine", [
+    "metadata/import prep only",
+    "headless",
+    "real render context",
+  ]);
   assert(!provingGround.includes("node cli/grb.mjs mission run smoke_boot"), "proving ground README should not primarily teach raw cli/grb.mjs path");
   assertIncludes(cliHelp, "grb.cmd init", "CLI help launcher truth");
   assertIncludes(cliHelp, "./grb init", "CLI help launcher truth");
   assertIncludes(cliHelp, "grb.cmd doctor", "CLI help doctor truth");
   assertIncludes(cliHelp, "doctor checks project readiness without launching Godot.", "CLI help doctor truth");
+  assertConcept(mcpReadme, "MCP headless doctrine", [
+    "grb_launch",
+    "windowed runtime sessions",
+    "real render context",
+    "headless",
+  ]);
+  assertConcept(mcpIndex, "MCP tool-schema headless doctrine", [
+    "screenshot-capable proof",
+    "not Godot --headless",
+  ]);
   assertIncludes(readme, "grb init` also records the full-repo GRB linkage", "README init linkage truth");
 }
 


### PR DESCRIPTION
## Summary

Ships GRB 2.0.2 as a small docs/tooling patch focused on agent proof discipline.

Adds:
- lightweight worktree preflight helper
- proof harness template
- proof report template
- AGENTS/README/mission-authoring guidance for preserving dirty work and honest W/R/E proof
- product-shape verifier checks for the new guidance

No runtime protocol, bridge behavior, compare logic, security architecture, mission runner behavior, proof-bundle logic, or packaging behavior changes.

## Validation

- node --check tools/grb_worktree_preflight.mjs
- node --check tools/verify_grb2_product_shape.mjs
- node --check mcp/index.js
- node --check mcp/check_versions.mjs
- node tools/verify_grb2_product_shape.mjs
- cd mcp && npm.cmd run verify:versions
- cd mcp && npm.cmd run verify:security
- cd mcp && npm.cmd run verify:grb2:shape
- live GRB smoke / aggregate release check if available
- git diff --check

## Notes

GRB 2.0.2 is a GitHub full-repo docs/tooling patch. Runtime bridge behavior is unchanged. Godot Asset Library update is intentionally deferred because the primary new value lives in the full-repo workflow.